### PR TITLE
Full GPG key fingerprint is provided

### DIFF
--- a/manifests/shipper/rsyslog.pp
+++ b/manifests/shipper/rsyslog.pp
@@ -25,7 +25,7 @@ class stack_logstash::shipper::rsyslog (
           repos       => ' ',
           release     => "${::lsbdistcodename}/",
           include_src => false,
-          key         => 'AEF0CF8E',
+          key         => '1362E120FE08D280780169DC894ECF17AEF0CF8E',
           before         => Tp::Install['rsyslog'],
         }
       }


### PR DESCRIPTION
This is to support release 1.8.0 of puppetlabs-apt